### PR TITLE
Rails 5 compatibility

### DIFF
--- a/lib/samsara/controller.rb
+++ b/lib/samsara/controller.rb
@@ -2,8 +2,8 @@ module Samsara::Controller
   extend ActiveSupport::Concern
 
   included do
-    before_filter :set_samsara_context
-    after_filter  :unset_samsara_context
+    before_action :set_samsara_context
+    after_action  :unset_samsara_context
   end
 
   def set_samsara_context


### PR DESCRIPTION
Rails 5 decided to rename "before_filter" -> "before_action" and "after_filter" -> "after_action". This PR fixes that.