### PR TITLE
Remove active storage

### DIFF
--- a/samsara.gemspec
+++ b/samsara.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord",  ">= 5.0"
   spec.add_dependency "activesupport", ">= 5.0"
-  spec.add_dependency "activestorage", ">= 5.0"
 
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "byebug"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,7 +3,7 @@ require_relative 'boot'
 # Pick the frameworks you want:
 require "active_model/railtie"
 require "active_record/railtie"
-require "active_storage/engine"
+#require "active_storage/engine"
 require "action_controller/railtie"
 # require "action_mailer/railtie"
 require "action_view/railtie"

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  #config.active_storage.service = :local
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  #config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
+  #config.active_storage.service = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
active storage doesn't really seem like a necessary dependency for samsara, and is causing some issues with rails 5.0