### PR TITLE
Update Rake after vulnerability found in <12.3.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,15 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
+# Fix to be able to use more recent Rake's without havin
+# to upgrade rspec
+module TempFixForRakeLastComment
+  def last_comment
+    last_description
+  end
+end
+Rake::Application.send :include, TempFixForRakeLastComment
+
 desc 'Run the spec testing suite'
 RSpec::Core::RakeTask.new(:spec)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,6 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-# Fix to be able to use more recent Rake's without havin
-# to upgrade rspec
-module TempFixForRakeLastComment
-  def last_comment
-    last_description
-  end
-end
-Rake::Application.send :include, TempFixForRakeLastComment
-
 desc 'Run the spec testing suite'
 RSpec::Core::RakeTask.new(:spec)
 

--- a/samsara.gemspec
+++ b/samsara.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord",  ">= 5.0"
-  spec.add_dependency "activesupport", ">= 5.0"
+  spec.add_dependency "activerecord",  "~> 5.0"
+  spec.add_dependency "activesupport", "~> 5.0"
 
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "rspec-rails", "~> 3.7"
 end


### PR DESCRIPTION
Added a small hack to not having to update rspec to a way newer version
as well.

Tests showed that Samsare is not ready yet for Rails > 5.x so changed
the gemspec to reflect that as well.